### PR TITLE
Replace YAML docs with JSON version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
-# docflow
+# Docflow Documentation Repository
+
+This repository contains analysis and documentation for the original **AZ_DSCommon** project.
+
+Configuration examples are now provided in **JSON v2** instead of YAML. A helper script under `tools/yaml_to_json.py` demonstrates how to convert legacy YAML files to JSON format.

--- a/dscommon/combined_documentation.md
+++ b/dscommon/combined_documentation.md
@@ -9,7 +9,7 @@ AZ_DSCommon/
 ├── app/            # Java code and Play templates
 │   ├── code/       # Core library classes (Docflow, actions, API)
 │   ├── controllers # HTTP API endpoints
-│   ├── docflow/    # YAML configuration and localization
+│   ├── docflow/    # JSON v2 configuration and localization
 │   ├── models/     # Generated document model classes
 │   └── views/      # Play views
 ├── conf/           # Play configuration (routes, dependencies, messages)
@@ -44,7 +44,7 @@ This document summarizes the source code structure and key components of the `AZ
 
 ## Overview
 
-The project is a Play Framework module that implements a document flow and rights management library. It provides models, controllers, and utilities for creating, updating, and managing document-based workflows. The code is primarily written in Java with supporting configuration in YAML and Play Framework files.
+The project is a Play Framework module that implements a document flow and rights management library. It provides models, controllers, and utilities for creating, updating, and managing document-based workflows. The code is primarily written in Java with supporting configuration in JSON (v2) and Play Framework files.
 
 ## Repository Structure
 
@@ -103,7 +103,7 @@ public class DocflowFile extends DocumentSimple {
 
 ### Configuration Loading
 
-Compilation steps load YAML definitions and link them to code. For instance, `Compiler030LoadFieldTypes` reads field type definitions from module directories:
+Compilation steps load JSON (v2) definitions and link them to code. For instance, `Compiler030LoadFieldTypes` reads field type definitions from module directories:
 
 ```java
 public class Compiler030LoadFieldTypes {
@@ -114,15 +114,36 @@ public class Compiler030LoadFieldTypes {
             final VirtualFile file = docflowConfig.currentModule.root.child(DocflowConfig.PATH_FIELD_TYPES);
             if (!file.exists())
                 continue;
-            // parsing YAML and merging field types
+            // parsing JSON and merging field types
         }
     }
 }
 ```
 
+### JSON Configuration Example
+
+```yaml
+docType:
+  name: Sample
+  fields:
+    - id: text
+      type: string
+```
+
+```json
+{
+  "docType": {
+    "name": "Sample",
+    "fields": [
+      {"id": "text", "type": "string"}
+    ]
+  }
+}
+```
+
 ## Conclusion
 
-`AZ_DSCommon` provides a comprehensive framework for document management in Play applications. It includes a dynamic compiler for YAML-defined documents, generated models with state machines, and HTTP endpoints for file and document operations.
+`AZ_DSCommon` provides a comprehensive framework for document management in Play applications. It includes a dynamic compiler for JSON-defined documents, generated models with state machines, and HTTP endpoints for file and document operations.
 # Модель документов и операции DSCommon
 
 Этот файл содержит обзор классов модели документов из Java-репозитория **AZ_DSCommon** и описывает основные операции, реализованные в пакете `code.docflow`.
@@ -214,7 +235,7 @@ HTTP‑контроллеры из пакета `controllers` предостав
 AngularJS‑клиент использует эти данные для генерации форм создания и
 редактирования. Для действий можно определить отдельные наборы групп полей,
 тем самым меняя видимость элементов интерфейса.
-Правила расположения полей описываются в YAML-файлах модуля `docflow` в
+Правила расположения полей описываются в JSON-файлах (v2) модуля `docflow` в
 разделах `forms` и `groups`. Каждому полю можно задать условие отображения,
 например `visible: state == 'DRAFT'`, что позволяет скрывать элементы в разных
 состояниях документа.
@@ -227,7 +248,7 @@ AngularJS‑клиент использует эти данные для ген�
 может изменять документ только на начальном этапе. Условные выражения позволяют
 учитывать значения полей, что обеспечивает тонкую настройку доступа.
 Права представляют собой битовые маски (`read`, `update`, `delete` и др.),
-которые сравниваются с ролями пользователя. В YAML можно указать условие вида
+которые сравниваются с ролями пользователя. В JSON можно указать условие вида
 `update: role == 'EDITOR' && state == 'DRAFT'`, ограничивая действие только для
 определённой роли и стадии документа.
 

--- a/tools/yaml_to_json.py
+++ b/tools/yaml_to_json.py
@@ -1,0 +1,25 @@
+import json
+import sys
+
+try:
+    import yaml
+except ImportError:
+    print("PyYAML is required")
+    sys.exit(1)
+
+
+def yaml_to_json(in_path, out_path=None):
+    with open(in_path, 'r', encoding='utf-8') as f:
+        data = yaml.safe_load(f)
+    if out_path:
+        with open(out_path, 'w', encoding='utf-8') as out:
+            json.dump(data, out, ensure_ascii=False, indent=2)
+    else:
+        print(json.dumps(data, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: python yaml_to_json.py <input.yml> [output.json]")
+        sys.exit(1)
+    yaml_to_json(sys.argv[1], sys.argv[2] if len(sys.argv) > 2 else None)


### PR DESCRIPTION
## Summary
- mention JSON configuration in repo overview
- add example JSON snippet in docs
- provide helper script for converting YAML
- update README about JSON v2 usage

## Testing
- `python tools/yaml_to_json.py sample.yml`

------
https://chatgpt.com/codex/tasks/task_e_68863fbd612483228e7051eb74230a4d