### PR TITLE
Add action parameters and change tracking

### DIFF
--- a/py_docflow/document.py
+++ b/py_docflow/document.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Tuple
 
 
 @dataclass
@@ -65,12 +65,14 @@ class DocumentVersioned(DocumentPersistent):
 
 @dataclass
 class DocumentHistoryEntry:
-    """Snapshot of a document revision."""
+    """Snapshot of a document revision with change metadata."""
 
     rev: int
     timestamp: datetime
     data: Dict[str, Any]
     action: str
+    params: Dict[str, Any] = field(default_factory=dict)
+    changes: Dict[str, Tuple[Any, Any]] = field(default_factory=dict)
 
 
 @dataclass

--- a/py_docflow/storage.py
+++ b/py_docflow/storage.py
@@ -1,6 +1,5 @@
-from dataclasses import asdict
 from datetime import datetime
-from typing import Dict, List, Type, Any
+from typing import Dict, List, Type, Any, Optional, Tuple
 from copy import deepcopy
 from .document import DocumentPersistent, DocumentVersioned, DocumentHistoryEntry
 
@@ -29,12 +28,21 @@ class InMemoryStorage:
         docs = self._data.setdefault(doc_type, {})
         docs[doc.id] = doc
 
-    def add_history(self, doc_type: str, doc: DocumentVersioned, action: str):
+    def add_history(
+        self,
+        doc_type: str,
+        doc: DocumentVersioned,
+        action: str,
+        params: Optional[Dict[str, Any]] = None,
+        changes: Optional[Dict[str, Tuple[Any, Any]]] = None,
+    ):
         entry = DocumentHistoryEntry(
             rev=doc.rev,
             timestamp=datetime.utcnow(),
-            data={k: v for k, v in asdict(doc).items() if k != "_doc_type"},
+            data={k: v for k, v in doc.__dict__.items() if k != "_doc_type"},
             action=action,
+            params=params or {},
+            changes=changes or {},
         )
         self._history.setdefault(doc_type, {}).setdefault(doc.id, []).append(entry)
 


### PR DESCRIPTION
## Summary
- extend `DocumentHistoryEntry` to store action params and field changes
- log params and changes in `InMemoryStorage.add_history`
- track document diffs and support custom actions in `Docflow`
- update tests to check new history details

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887bb8ff2408322bf288ca2d482636d