### PR TITLE
Improve rights handling with fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,9 @@ The Python version now includes a minimal file document model. Files can be
 persisted and retrieved entirely in memory using ``Docflow.persist_file`` and
 ``Docflow.get_file``. Versioned documents may also be recovered after deletion
 with ``Docflow.recover``.
+
+The latest update introduces a ``BitSet``-based rights model. ``RolesRegistry``
+assigns bit indexes to roles while each document type stores action permissions
+as bit masks for efficient checks. If a ``Docflow`` instance uses a different
+roles registry than the one used during type loading, rights fall back to the
+original dictionary-based checks to remain compatible.

--- a/py_docflow/__init__.py
+++ b/py_docflow/__init__.py
@@ -10,6 +10,7 @@ from .document import (
 )
 from .doctypes import DocType, Action, DocTypesRegistry
 from .docflow import Docflow
+from .rights import RolesRegistry, BitSet
 from .user import User
 from .storage import InMemoryStorage, Transaction
 
@@ -24,6 +25,8 @@ __all__ = [
     "Action",
     "DocTypesRegistry",
     "Docflow",
+    "RolesRegistry",
+    "BitSet",
     "InMemoryStorage",
     "Transaction",
     "User",

--- a/py_docflow/doctypes.py
+++ b/py_docflow/doctypes.py
@@ -1,6 +1,7 @@
 import json
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional
+from .rights import RolesRegistry, BitSet
 
 
 @dataclass
@@ -16,17 +17,27 @@ class DocType:
     actions: Dict[str, Action] = field(default_factory=dict)
     states: List[str] = field(default_factory=list)
     rights: Dict[str, Dict[str, bool]] = field(default_factory=dict)
+    rights_bits: Dict[str, BitSet] = field(default_factory=dict)
+    rights_roles: Optional[RolesRegistry] = None
     links: Dict[str, str] = field(default_factory=dict)
 
     @classmethod
-    def from_json(cls, data: Dict) -> 'DocType':
+    def from_json(cls, data: Dict, roles: Optional[RolesRegistry] = None) -> 'DocType':
         actions = {a['name']: Action(**a) for a in data.get('actions', [])}
+        rights = data.get('rights', {})
+        rights_bits: Dict[str, BitSet] = {}
+        if roles:
+            for action, role_map in rights.items():
+                allowed = [r for r, allow in role_map.items() if allow]
+                rights_bits[action.lower()] = roles.mask(allowed)
         return cls(
             name=data['name'],
             fields={f['id']: f['type'] for f in data.get('fields', [])},
             actions=actions,
             states=data.get('states', []),
-            rights=data.get('rights', {}),
+            rights=rights,
+            rights_bits=rights_bits,
+            rights_roles=roles,
             links=data.get('links', {})
         )
 
@@ -34,13 +45,14 @@ class DocType:
 class DocTypesRegistry:
     """Registry storing loaded document type definitions."""
 
-    def __init__(self):
+    def __init__(self, roles: Optional[RolesRegistry] = None):
         self.types: Dict[str, DocType] = {}
+        self.roles = roles or RolesRegistry()
 
     def load(self, path: str):
         with open(path, 'r', encoding='utf-8') as f:
             data = json.load(f)
-        doc_type = DocType.from_json(data)
+        doc_type = DocType.from_json(data, self.roles)
         self.types[doc_type.name] = doc_type
         return doc_type
 

--- a/py_docflow/rights.py
+++ b/py_docflow/rights.py
@@ -1,0 +1,69 @@
+from dataclasses import dataclass
+from typing import Dict, Iterable
+
+
+class BitSet:
+    """Simple integer-backed bit set."""
+
+    def __init__(self, value: int = 0):
+        self.value = int(value)
+
+    def set(self, index: int, flag: bool = True) -> 'BitSet':
+        if flag:
+            self.value |= 1 << index
+        else:
+            self.value &= ~(1 << index)
+        return self
+
+    def get(self, index: int) -> bool:
+        return (self.value >> index) & 1 == 1
+
+    def and_(self, other: 'BitSet') -> 'BitSet':
+        return BitSet(self.value & other.value)
+
+    def or_(self, other: 'BitSet') -> 'BitSet':
+        return BitSet(self.value | other.value)
+
+    def subtract(self, other: 'BitSet') -> 'BitSet':
+        return BitSet(self.value & ~other.value)
+
+    def invert(self, size: int) -> 'BitSet':
+        mask = (1 << size) - 1
+        return BitSet(~self.value & mask)
+
+    def is_empty(self) -> bool:
+        return self.value == 0
+
+    def to_list(self) -> Iterable[int]:
+        idx = 0
+        value = self.value
+        while value:
+            if value & 1:
+                yield idx
+            value >>= 1
+            idx += 1
+
+    def __repr__(self) -> str:
+        return f"BitSet({self.value})"
+
+
+@dataclass
+class RolesRegistry:
+    """Assign incremental bit indexes to roles."""
+
+    mapping: Dict[str, int] = None
+
+    def __post_init__(self):
+        if self.mapping is None:
+            self.mapping = {}
+
+    def index(self, role: str) -> int:
+        if role not in self.mapping:
+            self.mapping[role] = len(self.mapping)
+        return self.mapping[role]
+
+    def mask(self, roles: Iterable[str]) -> BitSet:
+        bs = BitSet()
+        for role in roles:
+            bs.set(self.index(role))
+        return bs

--- a/py_docflow_demo.py
+++ b/py_docflow_demo.py
@@ -8,7 +8,7 @@ def main():
     doc_type_b = registry.load('examples/doc_type_b.json')
     file_type = registry.load('examples/doc_file.json')
 
-    flow = Docflow()
+    flow = Docflow(roles=registry.roles)
     admin = User("alice", ["admin"])
     a = flow.create(doc_type_a, {"text": "hello"}, admin)
     b = flow.create(doc_type_b, {"text": "world"}, admin)


### PR DESCRIPTION
## Summary
- add fallback to legacy rights dict if bitset roles mismatch
- retain roles registry association on doc types
- document fallback behavior in README
- test rights checks with independent registries

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68889877749c8322b5b0aa52e71ccb37