### PR TITLE
Add Trasko query helper and expand docs

### DIFF
--- a/tests/test_trasko_metadata.py
+++ b/tests/test_trasko_metadata.py
@@ -1,0 +1,47 @@
+from trasko.metadata import generate_filter, generate_query_schema
+
+
+def test_generate_filter_basic():
+    method = {
+        "arguments": {
+            "list": [
+                {
+                    "name": "id",
+                    "type": "string",
+                    "init": "abc",
+                    "extra": {"label": "ID", "description": "Identifier"},
+                },
+                {
+                    "name": "active",
+                    "type": "boolean",
+                    "init": True,
+                    "extra": {"label": "Active"},
+                },
+            ]
+        }
+    }
+    res = generate_filter(method)
+    assert res["id"]["name"] == "ID"
+    assert res["id"]["type"] == "string"
+    assert res["id"]["data"]["value"] == "abc"
+    assert res["active"]["default"] is True
+
+
+def test_generate_query_schema_basic():
+    method = {
+        "name": "listRequests",
+        "arguments": {"list": [
+            {"name": "active", "type": "Boolean", "required": True}
+        ]},
+        "result": {"list": [
+            {"name": "count", "type": "Int"},
+            {"name": "items", "fields": [
+                {"name": "id", "type": "ID"}
+            ]}
+        ]}
+    }
+    query = generate_query_schema(method)
+    assert "query listRequests(" in query
+    assert "$active: Boolean!" in query
+    assert "listRequests(active: $active, context: $context)" in query
+    assert "count" in query and "items" in query and "id" in query

--- a/trasko/README.md
+++ b/trasko/README.md
@@ -1,0 +1,72 @@
+# Trasko Screen Building Overview
+
+This document summarizes how the AZ_trasko project builds screens using the
+`hope.js` library.  Metadata is loaded from the server and transformed into
+GraphQL schemas, filters and loaders that feed Vue components.
+
+## Metadata Module
+
+The metadata service loads the structure described in `server/docs` and then
+processes references with the loader module.  After `processTypeReferences` the
+metadata object contains fully linked types and methods ready for use.  The same
+service exposes a GraphQL module used to generate query schemas.
+
+## GraphQL Module
+
+The GraphQL module generates query schemas and filter structures.  Methods such
+as `getQuerySchemaForMethod`, `getFilterForMethod`, `setFilterValuesFromQuery`
+and `getFilterFieldValues` operate on the metadata tree.
+
+Filters can be customized by including or excluding fields and by removing words from captions. The returned object describes each filter field with the value stored in `data.value`.
+
+## Loader Module
+
+Loaders manage fetching data for forms via GraphQL and exposing the results to the Vue component. A loader is created per page using a standard template and can include pagination support.
+
+The loader obtains GraphQL objects from metadata, fills filter values from URL
+parameters, and executes the query. Pagination methods such as `prevPage`,
+`nextPage` and `setRowsPerPage` manipulate the filter and refresh the query.
+Each Vue page creates its own `loader.js` which extends a standard template from
+`metadata/modules/loader`.
+
+## Field Builder
+
+Vue components build form fields based on metadata using the fieldBuilder utility. Each field definition from metadata is transformed into Vue components with labels, hints and validation. (See `client/src/lib/fieldBuilder` in the source repository.)
+
+Hope's `link` function connects static metadata with runtime code, producing the model accessible in both the client and server. The client boot file `model.js` links the configuration with the generated code so components can access `this.$model`.
+
+## Python Example
+
+The file `metadata.py` contains a helper `generate_filter` that converts a method definition from `model.json` into a filter dictionary. A basic usage example:
+
+```python
+from trasko.metadata import generate_filter
+
+method = {
+    "arguments": {
+        "list": [
+            {"name": "id", "type": "string", "init": "abc", "extra": {"label": "ID"}},
+            {"name": "active", "type": "boolean", "init": True, "extra": {"label": "Active"}},
+        ]
+    }
+}
+
+filters = generate_filter(method)
+print(filters["id"])
+```
+
+The same module provides `generate_query_schema` which converts a method
+definition into a plain GraphQL query string:
+
+```python
+from trasko.metadata import generate_query_schema
+
+query = generate_query_schema({
+    "name": "listRequests",
+    "arguments": {"list": [{"name": "active", "type": "Boolean"}]},
+    "result": {"list": [{"name": "count"}]}
+})
+print(query)
+```
+
+See `tests/test_trasko_metadata.py` for unit tests of these helpers.

--- a/trasko/metadata.py
+++ b/trasko/metadata.py
@@ -1,0 +1,84 @@
+from typing import Dict, Any
+
+
+def generate_filter(method: Dict[str, Any]) -> Dict[str, Any]:
+    """Generate a filter structure from a method definition.
+
+    Parameters
+    ----------
+    method: dict
+        A method definition similar to those in AZ_trasko `model.json`.
+
+    Returns
+    -------
+    dict
+        Mapping of field names to filter descriptors with default values.
+    """
+    result: Dict[str, Any] = {}
+    arguments = method.get("arguments", {}).get("list", [])
+    for field in arguments:
+        name = field["name"]
+        extra = field.get("extra", {})
+        descriptor = {
+            "name": extra.get("label", name),
+            "description": extra.get("description", ""),
+            "type": field.get("type"),
+            "isArray": bool(field.get("array")),
+            "default": field.get("init"),
+            "data": {"value": field.get("init")},
+        }
+        result[name] = descriptor
+    return result
+
+
+def generate_query_schema(method: Dict[str, Any]) -> str:
+    """Generate a GraphQL query string from a method definition.
+
+    Parameters
+    ----------
+    method: dict
+        Structure describing a method, similar to AZ_trasko ``model.json``.
+
+    Returns
+    -------
+    str
+        GraphQL query string for executing the method.
+    """
+    name = method.get("name", "Query")
+
+    args = []
+    call_args = []
+    for field in method.get("arguments", {}).get("list", []):
+        arg_name = field["name"]
+        arg_type = field.get("type", "String")
+        if field.get("array"):
+            arg_type = f"[{arg_type}]"
+        if field.get("required"):
+            arg_type += "!"
+        args.append(f"${arg_name}: {arg_type}")
+        call_args.append(f"{arg_name}: ${arg_name}")
+
+    args.append("$context: String")
+    call_args.append("context: $context")
+
+    lines = [f"query {name}({', '.join(args)}) {{", f"  {name}({', '.join(call_args)}) {{"]
+
+    def render_fields(fields, indent=4):
+        for f in fields:
+            fname = f["name"]
+            sub = f.get("fields")
+            if sub:
+                lines.append(" " * indent + f"{fname} {{")
+                render_fields(sub, indent + 2)
+                lines.append(" " * indent + "}")
+            else:
+                lines.append(" " * indent + fname)
+
+    result_fields = method.get("result", {}).get("list")
+    if result_fields is None and isinstance(method.get("result"), dict):
+        result_fields = [{"name": k, **v} for k, v in method["result"].items()]
+    render_fields(result_fields or [])
+
+    lines.append("  }")
+    lines.append("}")
+    return "\n".join(lines)


### PR DESCRIPTION
## Summary
- expand Trasko documentation with details from AZ_trasko
- implement `generate_query_schema` for building GraphQL queries from metadata
- update tests for the new helper
- fix code blocks in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6888d3da293c8322a7670527fdac00e8